### PR TITLE
Replace grep-based pod readiness checks with kubectl wait

### DIFF
--- a/scripts/configure-kubernetes.sh
+++ b/scripts/configure-kubernetes.sh
@@ -71,12 +71,11 @@ kube_vip_version=${kube_vip_version}"
 _wait_for_pod_ready() {
     local namespace="$1" pod="$2"
     
-    log "Waiting for Pod ${pod} in namespace ${namespace} to be ready..."
-    until kubectl get pods -n "${namespace}" | grep "${pod}" | \
-    grep Running &>/dev/null; do
-        sleep 2
-        echo "Waiting..."
-    done
+        log "Waiting for Pod ${pod} in namespace ${namespace} to be ready..."
+        echo "Waiting for pod ${pod} in namespace ${namespace} to be ready..."
+        kubectl wait --namespace "${namespace}" \
+            --for=condition=Ready pod "${pod}" \
+            --timeout=120s
 }
 
 # Applies the Calico CNI plugin to the cluster using the latest release

--- a/scripts/install-addons.sh
+++ b/scripts/install-addons.sh
@@ -25,12 +25,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/addons/argocd.sh"
 _wait_for_pod_ready() {
     local namespace="$1" pod="$2"
     
-    log "Waiting for Pod ${pod} in namespace ${namespace} to be ready..."
-    until kubectl get pods -n "${namespace}" | grep "${pod}" | \
-    grep Running &>/dev/null; do
-        sleep 2
-        echo "Waiting..."
-    done
+        log "Waiting for Pod ${pod} in namespace ${namespace} to be ready..."
+        echo "Waiting for pod ${pod} in namespace ${namespace} to be ready..."
+        kubectl wait --namespace "${namespace}" \
+            --for=condition=Ready pod "${pod}" \
+            --timeout=120s
 }
 
 install_addons() {


### PR DESCRIPTION

Description:
Currently, the provisioning scripts check pod readiness using kubectl get pods | grep .... 

This approach is:

- Fragile (depends on string formatting, pod name patterns).
- Can produce false positives (partial matches).
- Harder to control timeouts/retries.

Proposed improvement:
Replace all grep-based readiness checks with kubectl wait, e.g.:

```
# Current (example)
kubectl get pods -n kube-system | grep coredns

# Suggested
kubectl wait --namespace kube-system \
  --for=condition=Ready pod \
  --selector=k8s-app=kube-dns \
  --timeout=120s

```

This makes pod readiness checks:
- More robust
- More portable across clusters
- Easier to maintain